### PR TITLE
Removing Search functionality from academics page.

### DIFF
--- a/academics.html
+++ b/academics.html
@@ -261,7 +261,7 @@
                     <!-- Side bar start -->
                     <div class="col-md-3">
                         <aside  class="side-bar">
-                            <div class="widget">
+                            <!-- <div class="widget">
                                 <h4 class="widget-title">Search</h4>
                                 <div class="search-bx">
                                     <form role="search" method="post">
@@ -272,7 +272,7 @@
                                             </span> </div>
                                     </form>
                                 </div>
-                            </div>
+                            </div> -->
                             <div class="icon-bx-wraper bx-style-1 p-a30 center m-b15">
                                 <div class="icon-bx-sm text-primary bg-white radius border-2 m-b20"> <a href="#" class="icon-cell"><i class="fa fa-user"></i></a> </div>
                                 <div class="icon-content">


### PR DESCRIPTION
**Issue** # 17
On the Academics page there was a Search Form.
![image](https://user-images.githubusercontent.com/57226467/144727507-85f479b6-e580-446d-9852-a45f2afb456f.png)
The Form was broken and would always return an error. 
This commit only hides the Search bar by commenting out the portion. It is by no means a solution to the problem.
![image](https://user-images.githubusercontent.com/57226467/144727648-f87aeaf3-f2ce-447c-b39a-8367273de36f.png)
